### PR TITLE
edit groups

### DIFF
--- a/app/assets/stylesheets/group.scss
+++ b/app/assets/stylesheets/group.scss
@@ -14,7 +14,7 @@
     text-align: center;
   }
 
-  .group-form__errors {
+  &__errors {
     margin: 30px 0;
     padding: 20px 40px;
     border: 1px solid #ddd;
@@ -40,7 +40,7 @@
     }
   }
 
-  .group-form__field {
+  &__field {
     margin-top: 30px;
     &:after {
       content: "";
@@ -48,7 +48,7 @@
       display: block;
     }
 
-    .group-form__field--left {
+    &--left {
       float: left;
       width: 30%;
       padding-right: 20px;
@@ -56,58 +56,28 @@
       box-sizing: border-box;
     }
 
-    .group-form__field--right {
+    &--right {
       float: right;
       width: 70%;
     }
-
-    .group-form__label {
-      display: block;
-      line-height: 50px;
-      font-weight: bold;
-      text-align: right;
-    }
-
-    .group-form__input {
-      float: left;
-      width: 100%;
-      line-height: 30px;
-      padding: 10px 15px;
-      box-sizing: border-box;
-    }
   }
 
-  .group-user {
-    padding: 0 15px;
+  &__label {
+    display: block;
     line-height: 50px;
-    font-size: 14px;
-    border-bottom: 1px solid #ddd;
-    &:after {
-      content: "";
-      clear: both;
-      display: block;
-    }
-
-    .group-user__name {
-      float: left;
-    }
-
-    .group-user__btn {
-      float: right;
-      display: inline-block;
-      cursor: pointer;
-
-      &.group-user__btn--add {
-        color: #38aef0;
-      }
-
-      &.group-user__btn--remove {
-        color: #f05050;
-      }
-    }
+    font-weight: bold;
+    text-align: right;
   }
 
-  .group-form__action-btn {
+  &__input {
+    float: left;
+    width: 100%;
+    line-height: 30px;
+    padding: 10px 15px;
+    box-sizing: border-box;
+  }
+
+  &__action-btn {
     display: inline-block;
     padding: 12px 20px;
     color: #fff;
@@ -115,3 +85,35 @@
     border: 0;
   }
 }
+
+.group-user {
+  padding: 0 15px;
+  line-height: 50px;
+  font-size: 14px;
+  border-bottom: 1px solid #ddd;
+  &:after {
+    content: "";
+    clear: both;
+    display: block;
+  }
+
+  &__name {
+    float: left;
+  }
+
+  &__btn {
+    float: right;
+    display: inline-block;
+    cursor: pointer;
+
+    &--add {
+      color: #38aef0;
+    }
+
+    &--remove {
+      color: #f05050;
+    }
+  }
+}
+
+

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,7 @@
 class GroupsController < ApplicationController
 
   def index
+    @groups = current_user.groups
   end
 
   def new

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -8,7 +8,7 @@ class GroupsController < ApplicationController
   end
 
   def create
-    @group = Group.new(create_params)
+    @group = Group.new(group_params)
     if @group.save
       redirect_to :root, notice: "グループが作成されました"
     else
@@ -17,14 +17,21 @@ class GroupsController < ApplicationController
   end
 
   def edit
+    @group = Group.find(params[:id])
   end
 
   def update
+    @group = Group.find(params[:id])
+    if @group.update_attributes(group_params)
+      redirect_to group_messages_path(params[:id]), notice: "グループが変更されました"
+    else
+      render :edit
+    end
   end
 
   private
 
-    def create_params
+    def group_params
       params.require(:group).permit(:name, user_ids: [])
     end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -22,7 +22,7 @@ class GroupsController < ApplicationController
 
   def update
     @group = Group.find(params[:id])
-    if @group.update_attributes(group_params)
+    if @group.update(group_params)
       redirect_to group_messages_path(params[:id]), notice: "グループが変更されました"
     else
       render :edit

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -18,11 +18,11 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    @group = Group.find(params[:id])
+    set_group
   end
 
   def update
-    @group = Group.find(params[:id])
+    set_group
     if @group.update(group_params)
       redirect_to group_messages_path(params[:id]), notice: "グループが変更されました"
     else
@@ -36,4 +36,7 @@ class GroupsController < ApplicationController
       params.require(:group).permit(:name, user_ids: [])
     end
 
+    def set_group
+      @group = Group.find(params[:id])
+    end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,7 @@
 class GroupsController < ApplicationController
 
+  before_action :set_group, only: [:edit, :update]
+
   def index
     @groups = current_user.groups
   end
@@ -18,11 +20,9 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    set_group
   end
 
   def update
-    set_group
     if @group.update(group_params)
       redirect_to group_messages_path(params[:id]), notice: "グループが変更されました"
     else

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,7 +1,7 @@
 class MessagesController < ApplicationController
   def index
     @groups = current_user.groups
-    @mgroup = Group.find(params[:group_id])
+    @group = Group.find(params[:group_id])
     @messages = [{name: "seo", date: "2016/09/21 06:16:55", body: "Hello world!"},
       {name: "neko", date: "2016/09/22 06:16:55", body: "Good bye world!"},
       {name: "neko", date: "2016/09/23 06:16:55", body: "See you later!"}]

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,7 +1,7 @@
 class MessagesController < ApplicationController
   def index
     @groups = current_user.groups
-    @messages_group = Group.find(params[:group_id])
+    @mgroup = Group.find(params[:group_id])
     @messages = [{name: "seo", date: "2016/09/21 06:16:55", body: "Hello world!"},
       {name: "neko", date: "2016/09/22 06:16:55", body: "Good bye world!"},
       {name: "neko", date: "2016/09/23 06:16:55", body: "See you later!"}]

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,8 +1,7 @@
 class MessagesController < ApplicationController
   def index
-    @user = current_user
     @groups = current_user.groups
-    @group = Group.find(params[:group_id])
+    @messages_group = Group.find(params[:group_id])
     @messages = [{name: "seo", date: "2016/09/21 06:16:55", body: "Hello world!"},
       {name: "neko", date: "2016/09/22 06:16:55", body: "Good bye world!"},
       {name: "neko", date: "2016/09/23 06:16:55", body: "See you later!"}]

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,7 @@ class MessagesController < ApplicationController
   def index
     @user = current_user
     @groups = current_user.groups
-    @group = {name: "sample", menbers: ["seo", "neko"]}
+    @group = Group.find(params[:group_id])
     @messages = [{name: "seo", date: "2016/09/21 06:16:55", body: "Hello world!"},
       {name: "neko", date: "2016/09/22 06:16:55", body: "Good bye world!"},
       {name: "neko", date: "2016/09/23 06:16:55", body: "See you later!"}]

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,44 @@
+= form_for @group do |f|
+  - if @group.errors.any?
+    .group-form__errors
+      %h2
+        = @group.errors.count
+        件のエラーが発生しました。
+        %ul
+          - @group.errors.full_messages.each do |msg|
+            %li
+              = msg
+  .group-form__field.clearfix
+    .group-form__field--left
+      = f.label :name, "グループ名", class: "group-form__label"
+    .group-form__field--right
+      =f.text_field :name, placeholder: "グループ名を入力してください", class: "group-form__input"
+  .group-form__field.clearfix
+    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+    /
+      <div class='group-form__field--left'>
+      <label class="group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
+      </div>
+      <div class='group-form__field--right'>
+      <div class='group-form__search clearfix'>
+      <input class='group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
+      </div>
+      <div id='user-search-result'></div>
+      </div>
+  .group-form__field.clearfix
+    .group-form__field--left
+      = f.label "チャットメンバー", class: "group-form__label"
+    .group-form__field--right
+      = f.collection_check_boxes(:user_ids, User.all, :id, :name)
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      /
+        <div id='group-users'>
+        <div class='group-user clearfix' id='group-user-22'>
+        <input name='chat_group[user_ids][]' type='hidden' value='22'>
+        <p class='group-user__name'>seo_kyohei</p>
+        </div>
+        </div>
+  .group-form__field.clearfix
+    .group-form__field--left
+    .group-form__field--right
+      = f.submit "Save",class: "group-form__action-btn"

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,11 +1,11 @@
-= form_for @group do |f|
-  - if @group.errors.any?
+= form_for group do |f|
+  - if group.errors.any?
     .group-form__errors
       %h2
-        = @group.errors.count
+        = group.errors.count
         件のエラーが発生しました。
         %ul
-          - @group.errors.full_messages.each do |msg|
+          - group.errors.full_messages.each do |msg|
             %li
               = msg
   .group-form__field.clearfix

--- a/app/views/groups/_group.html.haml
+++ b/app/views/groups/_group.html.haml
@@ -1,4 +1,4 @@
-= link_to '/' do
+= link_to group_messages_path(group.id) do
   %div.left__groups__group
     %div.left__groups__group__name
       = group.name

--- a/app/views/groups/_group.html.haml
+++ b/app/views/groups/_group.html.haml
@@ -1,6 +1,17 @@
-= link_to group_messages_path(group.id) do
-  %div.left__groups__group
-    %div.left__groups__group__name
-      = group.name
-    %div.left__groups__group__message
-      = group.name
+%div.left
+  %div.left__user
+    %div.left__user__name
+      = current_user.name
+    %div.left__user__edit
+      = link_to edit_user_path(current_user.id) do
+        = fa_icon 'cog'
+      = link_to new_group_path do
+        = fa_icon 'edit'
+  %div.left__groups
+    - current_user.groups.each do |group|
+      = link_to group_messages_path(group.id) do
+        %div.left__groups__group
+          %div.left__groups__group__name
+            = group.name
+          %div.left__groups__group__message
+            まだメッセージはありません

--- a/app/views/groups/_left.html.haml
+++ b/app/views/groups/_left.html.haml
@@ -8,8 +8,8 @@
       = link_to new_group_path do
         = fa_icon 'edit'
   %div.left__groups
-    - current_user.groups.each do |group|
-      = link_to group_messages_path(group.id) do
+    - groups.each do |group|
+      = link_to group_messages_path(group) do
         %div.left__groups__group
           %div.left__groups__group__name
             = group.name

--- a/app/views/groups/_left.html.haml
+++ b/app/views/groups/_left.html.haml
@@ -1,17 +1,17 @@
-%div.left
-  %div.left__user
-    %div.left__user__name
+.left
+  .left__user
+    .left__user__name
       = current_user.name
-    %div.left__user__edit
+    .left__user__edit
       = link_to edit_user_path(current_user.id) do
         = fa_icon 'cog'
       = link_to new_group_path do
         = fa_icon 'edit'
-  %div.left__groups
+  .left__groups
     - groups.each do |group|
       = link_to group_messages_path(group) do
-        %div.left__groups__group
-          %div.left__groups__group__name
+        .left__groups__group
+          .left__groups__group__name
             = group.name
-          %div.left__groups__group__message
+          .left__groups__group__message
             まだメッセージはありません

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,16 +1,20 @@
 .group-form
   %h1 チャットグループ編集
-  %form#edit_chat_group_22.edit_chat_group{"accept-charset" => "UTF-8", :action => "/chat_groups/22", :method => "post"}
-    .group-form__errors
-      %h2
-        1件のエラーが発生しました。
-        %ul
-          %li エラーです
+  = form_for @group do |f|
+    - if @group.errors.any?
+      .group-form__errors
+        %h2
+          = @group.errors.count
+          件のエラーが発生しました。
+          %ul
+            - @group.errors.full_messages.each do |msg|
+              %li
+                = msg
     .group-form__field.clearfix
       .group-form__field--left
-        %label.group-form__label{:for => "chat_group_name"} グループ名
+        = f.label :name, "グループ名", class: "group-form__label"
       .group-form__field--right
-        %input#chat_group_name.group-form__input{:name => "chat_group[name]", :placeholder => "グループ名を入力してください", :type => "text", :value => "ほげー"}/
+        = f.text_field :name, placeholder: "#{@group.name}", class: "group-form__input"
     .group-form__field.clearfix
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
       /
@@ -25,9 +29,10 @@
         </div>
     .group-form__field.clearfix
       .group-form__field--left
-        %label.group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+        = f.label "チャットメンバー", class: "group-form__label"
+      .group-form__field--right
+        = f.collection_check_boxes(:user_ids, User.all, :id, :name)
     .group-form__field.clearfix
       .group-form__field--left
       .group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        %input.group-form__action-btn{"data-disable-with" => "Save", :name => "commit", :type => "submit", :value => "Save"}/
+        = f.submit "Save", class: "group-form__action-btn"

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,3 +1,3 @@
 .group-form
   %h1 チャットグループ編集
-  = render partial: "form", locals: {group: @group}
+  = render 'form', group: @group

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,38 +1,4 @@
 .group-form
   %h1 チャットグループ編集
   = form_for @group do |f|
-    - if @group.errors.any?
-      .group-form__errors
-        %h2
-          = @group.errors.count
-          件のエラーが発生しました。
-          %ul
-            - @group.errors.full_messages.each do |msg|
-              %li
-                = msg
-    .group-form__field.clearfix
-      .group-form__field--left
-        = f.label :name, "グループ名", class: "group-form__label"
-      .group-form__field--right
-        = f.text_field :name, placeholder: "#{@group.name}", class: "group-form__input"
-    .group-form__field.clearfix
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div class='group-form__field--left'>
-        <label class="group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-        </div>
-        <div class='group-form__field--right'>
-        <div class='group-form__search clearfix'>
-        <input class='group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-        </div>
-        <div id='user-search-result'></div>
-        </div>
-    .group-form__field.clearfix
-      .group-form__field--left
-        = f.label "チャットメンバー", class: "group-form__label"
-      .group-form__field--right
-        = f.collection_check_boxes(:user_ids, User.all, :id, :name)
-    .group-form__field.clearfix
-      .group-form__field--left
-      .group-form__field--right
-        = f.submit "Save", class: "group-form__action-btn"
+    = render "form"

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,4 +1,3 @@
 .group-form
   %h1 チャットグループ編集
-  = form_for @group do |f|
-    = render "form"
+  = render partial: "form", locals: {group: @group}

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,33 +1,33 @@
-.chat-group-form
+.group-form
   %h1 チャットグループ編集
   %form#edit_chat_group_22.edit_chat_group{"accept-charset" => "UTF-8", :action => "/chat_groups/22", :method => "post"}
-    .chat-group-form__errors
+    .group-form__errors
       %h2
         1件のエラーが発生しました。
         %ul
           %li エラーです
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{:name => "chat_group[name]", :placeholder => "グループ名を入力してください", :type => "text", :value => "ほげー"}/
-    .chat-group-form__field.clearfix
+    .group-form__field.clearfix
+      .group-form__field--left
+        %label.group-form__label{:for => "chat_group_name"} グループ名
+      .group-form__field--right
+        %input#chat_group_name.group-form__input{:name => "chat_group[name]", :placeholder => "グループ名を入力してください", :type => "text", :value => "ほげー"}/
+    .group-form__field.clearfix
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
       /
-        <div class='chat-group-form__field--left'>
-        <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
+        <div class='group-form__field--left'>
+        <label class="group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
         </div>
-        <div class='chat-group-form__field--right'>
-        <div class='chat-group-form__search clearfix'>
-        <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
+        <div class='group-form__field--right'>
+        <div class='group-form__search clearfix'>
+        <input class='group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
         </div>
         <div id='user-search-result'></div>
         </div>
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
+    .group-form__field.clearfix
+      .group-form__field--left
+        %label.group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .group-form__field.clearfix
+      .group-form__field--left
+      .group-form__field--right
         / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        %input.chat-group-form__action-btn{"data-disable-with" => "Save", :name => "commit", :type => "submit", :value => "Save"}/
+        %input.group-form__action-btn{"data-disable-with" => "Save", :name => "commit", :type => "submit", :value => "Save"}/

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,1 @@
+= render "group"

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,1 +1,1 @@
-= render partial: "left", locals: {groups: @groups}
+= render 'left', groups: @groups

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,1 +1,1 @@
-= render "group"
+= render partial: "left", locals: {groups: @groups}

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,47 +1,4 @@
 .group-form
   %h1 新規チャットグループ
   = form_for @group do |f|
-    - if @group.errors.any?
-      .group-form__errors
-        %h2
-          = @group.errors.count
-          件のエラーが発生しました。
-          %ul
-            - @group.errors.full_messages.each do |msg|
-              %li
-                = msg
-    .group-form__field.clearfix
-      .group-form__field--left
-        = f.label :name, "グループ名", class: "group-form__label"
-      .group-form__field--right
-        =f.text_field :name, placeholder: "グループ名を入力してください", class: "group-form__input"
-    .group-form__field.clearfix
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div class='group-form__field--left'>
-        <label class="group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-        </div>
-        <div class='group-form__field--right'>
-        <div class='group-form__search clearfix'>
-        <input class='group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-        </div>
-        <div id='user-search-result'></div>
-        </div>
-    .group-form__field.clearfix
-      .group-form__field--left
-        = f.label "チャットメンバー", class: "group-form__label"
-      .group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        = f.collection_check_boxes(:user_ids, User.all, :id, :name)
-        / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-        /
-          <div id='group-users'>
-          <div class='group-user clearfix' id='group-user-22'>
-          <input name='chat_group[user_ids][]' type='hidden' value='22'>
-          <p class='group-user__name'>seo_kyohei</p>
-          </div>
-          </div>
-    .group-form__field.clearfix
-      .group-form__field--left
-      .group-form__field--right
-        = f.submit "Save",class: "group-form__action-btn"
+    = render "form"

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,3 +1,3 @@
 .group-form
   %h1 新規チャットグループ
-  = render partial: "form", locals: {group: @group}
+  = render 'form', group: @group

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,4 +1,3 @@
 .group-form
   %h1 新規チャットグループ
-  = form_for @group do |f|
-    = render "form"
+  = render partial: "form", locals: {group: @group}

--- a/app/views/messages/_messages.html.haml
+++ b/app/views/messages/_messages.html.haml
@@ -1,9 +1,9 @@
-%div.right__log__message
-  %div.right__log__message__name
+.right__log__message
+  .right__log__message__name
     = message[:name]
 
-  %div.right__log__message__date
+  .right__log__message__date
     = message[:date]
 
-  %div.right__log__message__body
+  .right__log__message__body
     = message[:body]

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,14 +1,4 @@
-%div.left
-  %div.left__user
-    %div.left__user__name
-      = current_user.name
-    %div.left__user__edit
-      = link_to edit_user_path(current_user.id) do
-        = fa_icon 'cog'
-      = link_to new_group_path do
-        = fa_icon 'edit'
-  %div.left__groups
-    = render @groups
+= render "groups/group"
 
 %div.right
   %div.right__group

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,24 +1,24 @@
 = render partial: "groups/left", locals: {groups: @groups}
 
-%div.right
-  %div.right__group
-    %div.right__group__user
-      %div.right__group__user__name
+.right
+  .right__group
+    .right__group__user
+      .right__group__user__name
         = @messages_group.name
-      %div.right__group__user__members
+      .right__group__user__members
         %ul
           Member:
           - @messages_group.users.each do |user|
             %li<
               = user.name
-    %div.right__group__edit
+    .right__group__edit
       = link_to edit_group_path(@messages_group) do
-        %div.right__group__edit__button
+        .right__group__edit__button
           Edit
-  %div.right__log
+  .right__log
     - @messages.each do |message|
       = render partial: "messages", locals: { message: message }
-  %div.right__form
+  .right__form
     = form_for(@chat) do |f|
       = f.text_field :body, class: "right__form__text", placeholder: "type message"
       = f.label :image , class: "right__form__image" do

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,18 +1,18 @@
-= render "groups/group"
+= render partial: "groups/left", locals: {groups: @groups}
 
 %div.right
   %div.right__group
     %div.right__group__user
       %div.right__group__user__name
-        = @group.name
+        = @messages_group.name
       %div.right__group__user__members
         %ul
           Member:
-          - @group.users.each do |user|
+          - @messages_group.users.each do |user|
             %li<
               = user.name
     %div.right__group__edit
-      = link_to edit_group_path(params[:group_id]) do
+      = link_to edit_group_path(@messages_group) do
         %div.right__group__edit__button
           Edit
   %div.right__log

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,4 +1,4 @@
-= render partial: "groups/left", locals: {groups: @groups}
+= render 'groups/left', groups: @groups
 
 .right
   .right__group
@@ -17,7 +17,7 @@
           Edit
   .right__log
     - @messages.each do |message|
-      = render partial: "messages", locals: { message: message }
+      = render 'messages', message: message
   .right__form
     = form_for(@chat) do |f|
       = f.text_field :body, class: "right__form__text", placeholder: "type message"

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -22,7 +22,7 @@
             %li<
               = member
     %div.right__group__edit
-      = link_to '/' do
+      = link_to edit_group_path(:id) do
         %div.right__group__edit__button
           Edit
   %div.right__log

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -14,15 +14,15 @@
   %div.right__group
     %div.right__group__user
       %div.right__group__user__name
-        = @group[:name]
+        = @group.name
       %div.right__group__user__members
         %ul
           Member:
-          - @group[:menbers].each do |member|
+          - @group.users.each do |user|
             %li<
-              = member
+              = user.name
     %div.right__group__edit
-      = link_to edit_group_path(:id) do
+      = link_to edit_group_path(5) do
         %div.right__group__edit__button
           Edit
   %div.right__log

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -4,15 +4,15 @@
   .right__group
     .right__group__user
       .right__group__user__name
-        = @messages_group.name
+        = @group.name
       .right__group__user__members
         %ul
           Member:
-          - @messages_group.users.each do |user|
+          - @group.users.each do |user|
             %li<
               = user.name
     .right__group__edit
-      = link_to edit_group_path(@messages_group) do
+      = link_to edit_group_path(@group) do
         .right__group__edit__button
           Edit
   .right__log

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -22,7 +22,7 @@
             %li<
               = user.name
     %div.right__group__edit
-      = link_to edit_group_path(5) do
+      = link_to edit_group_path(params[:group_id]) do
         %div.right__group__edit__button
           Edit
   %div.right__log

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root 'messages#index'
+  root 'groups#index'
   resources :users, only: [:edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'messages#index'
-  resources :messages, only: :index
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:index, :new, :create, :edit, :update]
+  resources :groups, only: [:index, :new, :create, :edit, :update] do
+    resources :messages, only: :index
+  end
 end


### PR DESCRIPTION
# WHAT
- group/1/messagesのようなpathにする
- groupのeditを押した際のリンクを正しいものに変更する
- form_for を用いる
- edit update コントローラーの作成
- rootをgroup#indexに変更

# WHY
- どのグループに対して送信されたかわかるようにするため
- 正しいリンクにするため
- モデルに保存するため簡略化
- 編集機能を実装するため
- 最初に表示されるviewを変えるため